### PR TITLE
Add R CMD check workflow to main branch

### DIFF
--- a/.github/workflows/r-lib-check.yaml
+++ b/.github/workflows/r-lib-check.yaml
@@ -4,6 +4,9 @@ name: R-CMD-check (r-lib)
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 jobs:
   R-CMD-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This extra check is added to solve a caching issue within GitHub actions. Caches created on the default branch (main) are available to all branches, but caches created on other branches are only available within that branch. This means that the R dependencies will not be cached between pull requests unless the workflow also runs on the default branch.

This can be solved easily by adding a check on pushes to main, but there may be a slightly more ideal fix if we look into this further. Additionally, running the check again adds an extra layer of protection to the main branch.