### PR TITLE
Control node size

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CancerEvolutionVisualization
 Title: Publication Quality Phylogenetic Tree Plots
 Version: 3.0.0
-Date: 2024-09-06
+Date: 2024-09-23
 Authors@R: c(
 	person("Paul Boutros", role = "cre", email = "PBoutros@mednet.ucla.edu"),
 	person("Adriana Salcedo", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CancerEvolutionVisualization
 Title: Publication Quality Phylogenetic Tree Plots
 Version: 3.0.0
-Date: 2024-08-28
+Date: 2024-09-06
 Authors@R: c(
 	person("Paul Boutros", role = "cre", email = "PBoutros@mednet.ucla.edu"),
 	person("Adriana Salcedo", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# CancerEvolutionVisualization 3.0.0 (2024-08-28)
+# CancerEvolutionVisualization 3.0.0 (2024-09-23)
 
 ## Added
 * Dendrogram mode

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Plotting functions to visualize the distribution of clones across the genome.
 * Documentation for heatmaps and clone-genome distribution plot
 * Option to disable node drawing with node-by-node control
+* Node-by-node control of node size
   
 ## Update
 * Fixed angle calculation bug where child angles do not follow

--- a/R/SRCGrob.R
+++ b/R/SRCGrob.R
@@ -17,7 +17,6 @@ SRCGrob <- function(
     node.text.cex = 0.85,
     main.y = NULL,
     main.cex = 1.7,
-    node.radius = 0.1,
     node.text.line.dist = 0.1,
     colour.scheme = CancerEvolutionVisualization::colours,
     add.normal = FALSE,
@@ -53,6 +52,7 @@ SRCGrob <- function(
     wid <- 1.2;
     spread <- 1;
     cluster.list <- NULL;
+    node.radius <- 0.1;
 
     axis.cex <- list(
         x = xaxis.cex,

--- a/R/add.nodes.R
+++ b/R/add.nodes.R
@@ -36,7 +36,7 @@ add.node.ellipse <- function(
 	    name = node.grob.name,
 	    x = unit(circle.nodes$x, 'native'),
 	    y = unit(circle.nodes$y, 'native'),
-	    size = node.radius * (1 + 0.2 * nchar(circle.nodes$plot.lab)),
+	    size = node.radius * clone.out$v$node.size * (1 + 0.2 * nchar(circle.nodes$plot.lab)),
 	    ar = 1 - log2(nchar(circle.nodes$plot.lab)) / 10,
 	    gp = gpar(
 	        fill = circle.nodes$node.colour,

--- a/R/adjust.tree.R
+++ b/R/adjust.tree.R
@@ -24,10 +24,7 @@ adjust.lengths <- function(x, length.cols, node.df) {
     }
 
 adjust.branch.lengths <- function(node.df, tree, node.radius, scale1) {
-    if (is.null(node.df$node.radius)) {
-        node.radius <- node.radius / scale1;
-        node.df$node.radius <- rep(node.radius, nrow(node.df));
-        }
+    node.df$node.radius <- node.radius * node.df$node.size / scale1;
 
     node.df$node.radius[node.df$id == -1] <- 0;
     node.df[!node.df$draw.node, 'node.radius'] <- 0;

--- a/R/prep.tree.R
+++ b/R/prep.tree.R
@@ -82,6 +82,15 @@ prep.tree <- function(
             }
         }
 
+    if (!('node.size' %in% colnames(tree.df))) {
+        tree.df$node.size <- NA;
+        }
+    tree.df$node.size <- prep.column.values(
+        tree.df$node.size,
+        default.values = 1,
+        conversion.fun = as.numeric
+        );
+
     tree.df <- prep.draw.node.setting(tree.df);
     tree.df <- prep.edge.colours(tree.df);
 
@@ -206,6 +215,7 @@ prep.tree <- function(
         color = colour.scheme[1:(nrow(tree.df) + 1)],
         angle = c(NA, tree.df$angle),
         draw.node = c(NA, tree.df$draw.node),
+        node.size = c(NA, tree.df$node.size),
         spread = c(NA, tree.df$spread),
         node.colour = c(NA, tree.df$node.col),
         node.label.colour = c(NA, tree.df$node.label.col),

--- a/R/prep.tree.R
+++ b/R/prep.tree.R
@@ -85,11 +85,7 @@ prep.tree <- function(
     if (!('node.size' %in% colnames(tree.df))) {
         tree.df$node.size <- NA;
         }
-    tree.df$node.size <- prep.column.values(
-        tree.df$node.size,
-        default.values = 1,
-        conversion.fun = as.numeric
-        );
+    tree.df$node.size <- prep.node.size(tree.df);
 
     tree.df <- prep.draw.node.setting(tree.df);
     tree.df <- prep.edge.colours(tree.df);
@@ -617,6 +613,17 @@ check.dendrogram.angle.conflicts <- function(tree.df) {
     if (any(conflicts)) {
         warning('"x" values override "angle" and "spread" values in dendrogram mode.')
         }
+    }
+
+prep.node.size <- function(tree.df) {
+    node.size <- prep.column.values(
+        tree.df$node.size,
+        default.values = 1,
+        conversion.fun = as.numeric
+        );
+    node.size[tree.df$draw.node == FALSE] <- 0;
+
+    return(node.size);
     }
 
 # default.values must be either a scalar or matching length of column.values.

--- a/man/SRCGrob.Rd
+++ b/man/SRCGrob.Rd
@@ -25,7 +25,6 @@ SRCGrob(
     node.text.cex = 0.85,
     main.y = NULL,
     main.cex = 1.7,
-    node.radius = 0.1,
     node.text.line.dist = 0.1,
     colour.scheme = CancerEvolutionVisualization::colours,
     add.normal = FALSE,
@@ -67,7 +66,6 @@ SRCGrob(
   \item{node.text.cex}{Font size for the node text}
   \item{main.y}{Move the main plot title position up or down}
   \item{main.cex}{Font size for the main plot title}
-  \item{node.radius}{Node size}
   \item{node.text.line.dist}{
   Distance between node text and tree branches (as a value between 0 and 1)
   }

--- a/tests/testthat/helper-multitest.R
+++ b/tests/testthat/helper-multitest.R
@@ -2,7 +2,6 @@ create.test.tree <- function(tree, node.text, sample, ...) {
     out <- SRCGrob(
         tree,
         node.text,
-        node.radius = 0.1,
         node.text.cex = 0.85,
         scale1 = 0.9,
         yaxis1.label = 'PGA',

--- a/tests/testthat/test-prep.tree.R
+++ b/tests/testthat/test-prep.tree.R
@@ -1016,13 +1016,13 @@ test_that(
             node.size = rep(2, 4),
             draw.node = TRUE
         );
-        
+
         hidden.nodes <- 2:3;
         tree.df$draw.node[hidden.nodes] <- FALSE;
-        
+
         result <- prep.node.size(tree.df);
         expected.result <- tree.df$node.size;
         expected.result[hidden.nodes] <- 0;
-        
+
         expect_equal(result, expected.result);
     });

--- a/tests/testthat/test-prep.tree.R
+++ b/tests/testthat/test-prep.tree.R
@@ -992,3 +992,37 @@ test_that(
             regexp = 'spread'
             );
     });
+
+test_that(
+    'prep.node.size replaces NAs with 1', {
+        tree.df <- data.frame(
+            node.size = rep(2, 4),
+            draw.node = TRUE
+            );
+
+        NA.indices <- 2:3;
+        tree.df$node.size[NA.indices] <- NA;
+
+        result <- prep.node.size(tree.df);
+        expected.result <- tree.df$node.size;
+        expected.result[NA.indices] <- 1;
+
+        expect_equal(result, expected.result);
+    });
+
+test_that(
+    'prep.node.size sets node size to 0 when node is not drawn', {
+        tree.df <- data.frame(
+            node.size = rep(2, 4),
+            draw.node = TRUE
+        );
+        
+        hidden.nodes <- 2:3;
+        tree.df$draw.node[hidden.nodes] <- FALSE;
+        
+        result <- prep.node.size(tree.df);
+        expected.result <- tree.df$node.size;
+        expected.result[hidden.nodes] <- 0;
+        
+        expect_equal(result, expected.result);
+    });


### PR DESCRIPTION
# Description

Closes #80. Allows node-by-node control of the size of the node. This accounts for the node size using the existing algorithm for positioning nodes, which accounts for node radius. While this could be be slightly improved for a pixel-perfect solution, that is beyond the scope of these changes.

![Screenshot 2024-09-06 at 12 40 28 PM](https://github.com/user-attachments/assets/ba47ff12-a7fd-4bdb-aba6-9cb885ea6a52)


<!-- 
Admin/maintainer: please edit the 'Pipeline Run Results' or 'Analysis Results' sections as needed for your project repo.  
Then commit/push the changes so everyone uses this template for future PRs.

For example, if your project is a `pipeline`, then create a 'Pipeline Run Results' section.

If your project is a general data analysis project, then you may want to require an 'Analysis Results' section in order to test
code from each PR to help prevent creating new bugs.
-->

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

