### PR TITLE
Fix text annotation

### DIFF
--- a/R/add.text.R
+++ b/R/add.text.R
@@ -497,9 +497,9 @@ add.text2 <- function(
     node.radius <- node.radius / scale;
     node.text <- node.text[node.text$node %in% tree$tip, ];
 
-    node.list <- vector("list", nrow(tree));
-    node.text.col <- vector("list", nrow(tree));
-    node.text.fontface <- vector("list", nrow(tree));
+    node.list <- vector('list', nrow(tree));
+    node.text.col <- vector('list', nrow(tree));
+    node.text.fontface <- vector('list', nrow(tree));
 
     # Loop to assign text to nodes
     for (i in seq_len(nrow(node.text))) {

--- a/R/add.text.R
+++ b/R/add.text.R
@@ -497,8 +497,30 @@ add.text2 <- function(
     node.radius <- node.radius / scale;
     node.text <- node.text[node.text$node %in% tree$tip, ];
 
-    node.list <- data.frame(row.names = rownames(tree));
-    node.text.col <- node.text.fontface <- lapply
+    node.list <- vector("list", nrow(tree));
+    node.text.col <- vector("list", nrow(tree));
+    node.text.fontface <- vector("list", nrow(tree));
+
+    # Loop to assign text to nodes
+    for (i in seq_len(nrow(node.text))) {
+        text.row <- node.text[i, ];
+        pos <- which(tree$tip == text.row$node);
+        text.value <- text.row$name;
+
+        # Check if the text contains an underscore and parse if necessary
+        if (length(grep('_', text.value)) > 0) {
+            text.split <- strsplit(text.value, split = '_')[[1]];
+            node.text.value <- text.split[1];
+            amp <- text.split[2];
+            call <- paste0(node.text.value, '^\'A', amp, '\'');
+            text.value <- parse(text = call);
+            }
+
+        # Assign text value, color, and font face
+        node.list[[pos]] <- c(node.list[[pos]], text.value);
+        node.text.col[[pos]] <- c(node.text.col[[pos]], if (!is.na(text.row$col)) text.row$col else 'black');
+        node.text.fontface[[pos]] <- c(node.text.fontface[[pos]], if (!is.na(text.row$fontface)) text.row$fontface else 'plain');
+        }
 
     tree.max.adjusted <- apply(
         tree,
@@ -533,7 +555,7 @@ add.text2 <- function(
         );
     tree.max.adjusted$tipx <- (
         tree.max.adjusted$tipx -
-        -angle.modifier * node.radius * sin(tree.max.adjusted$angle)
+        angle.modifier * node.radius * sin(tree.max.adjusted$angle)
         );
     tree.max.adjusted$basey <- (
         tree.max.adjusted$basey +
@@ -541,7 +563,7 @@ add.text2 <- function(
         );
     tree.max.adjusted$tipy <- (
         tree.max.adjusted$tipy -
-        -angle.modifier * node.radius * cos(tree.max.adjusted$angle)
+        angle.modifier * node.radius * cos(tree.max.adjusted$angle)
         );
 
     # Push a viewport the same size as the final panel
@@ -552,7 +574,7 @@ add.text2 <- function(
         pushViewport(viewport(
             height = unit(panel.height, 'inches'),
             name = 'ref',
-            width = unit(panel.width,'inches'),
+            width = unit(panel.width, 'inches'),
             xscale = xlims,
             yscale = c(ymax, -2)
             ));
@@ -563,8 +585,8 @@ add.text2 <- function(
     tree.max.adjusted$y0 <- convertY(unit(tree.max.adjusted$basey, 'native'), 'inches', valueOnly = TRUE);
     tree.max.adjusted$y1 <- convertY(unit(tree.max.adjusted$tipy, 'native'), 'inches', valueOnly = TRUE);
 
-    tree.max.adjusted$y <- convertY(unit(tree.max$tipy, 'native'), 'inches', valueOnly = TRUE); # Actual node positions
-    tree.max.adjusted$x <- convertX(unit(tree.max$tipx, 'native'), 'inches', valueOnly = TRUE);
+    tree.max.adjusted$y <- convertY(unit(tree.max.adjusted$tipy, 'native'), 'inches', valueOnly = TRUE); # Actual node positions
+    tree.max.adjusted$x <- convertX(unit(tree.max.adjusted$tipx, 'native'), 'inches', valueOnly = TRUE);
 
     tree.max.adjusted$slope <- (tree.max.adjusted$y1 - tree.max.adjusted$y0) / (tree.max.adjusted$x1 - tree.max.adjusted$x0);
     tree.max.adjusted$intercept <- tree.max.adjusted$y1 - tree.max.adjusted$slope * tree.max.adjusted$x1;
@@ -597,7 +619,6 @@ add.text2 <- function(
             children = text.grob.gList,
             vp = make.plot.viewport(clone.out, clip = 'off')
             );
-
         return(text.tree);
         }
 
@@ -615,4 +636,4 @@ add.text2 <- function(
         );
 
     return(list(text.tree, tree.max.adjusted));
-	}
+    }


### PR DESCRIPTION
# Description
Fixing 2 main issues:
 1. Text annotations are missing from plot.
 2. Test positioning assume radial edges, need to optionally adjust for when using 'dendrogram' mode

The first problem is due to a missing segment from the old ([pre-plyr](https://github.com/uclahs-cds/package-CancerEvolutionVisualization/blob/6ddc412150cd2d114aec961f6d908c24d4a1c0d2/R/add.text.R)) version, where line 517-546 is missing

### Closes #139 

<!-- 
Admin/maintainer: please edit the 'Pipeline Run Results' or 'Analysis Results' sections as needed for your project repo.  
Then commit/push the changes so everyone uses this template for future PRs.

For example, if your project is a `pipeline`, then create a 'Pipeline Run Results' section.

If your project is a general data analysis project, then you may want to require an 'Analysis Results' section in order to test
code from each PR to help prevent creating new bugs.
-->
# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [ ] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [ ] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [ ] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [ ] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [ ] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [ ] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [ ] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

