### PR TITLE
Fix bug in simple dendrograms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 
 ## Bug
 * Resolved issue where the spread parameter was not applied in dendrogram mode.
+* Resolved issue for simple dendrogram trees ( < 6 nodes or binary tree), where node angles were not calculated correctly.
 
 # CancerEvolutionVisualization 2.0.1 (2023-11-17)
 

--- a/R/calculate.clone.polygons.R
+++ b/R/calculate.clone.polygons.R
@@ -332,8 +332,8 @@ compute.clones <- function(
 	v <- rbind(root, v);
 	v <- count.leaves.per.node(v);
 	if (no.ccf) {
-	    tree$angle <- if ((is.null(fixed.angle) && nrow(v) > 6) || any(table(v$parent) > 2)) {
-    		tau <- -(pi / 2.5);
+	    tree$angle <- if ((is.null(fixed.angle) && nrow(v) > 6) || any(table(v$parent) > 2) || any(v$mode == 'dendrogram')) {
+			tau <- -(pi / 2.5);
     		vi <- v[v$parent == -1, ];
     		calculate.angles.radial(v, tree, spread, abs(tau));
 	    } else {

--- a/R/create.phylogenetic.tree.R
+++ b/R/create.phylogenetic.tree.R
@@ -9,6 +9,7 @@ create.phylogenetic.tree <- function(
     ...
     ) {
 
+    tree <- as.data.frame(tree);
     if ('node.id' %in% colnames(tree)) {
         rownames(tree) <- tree$node.id;
         }


### PR DESCRIPTION
# Description
When dendrogram mode is selected for trees with <6 nodes or a binary tree, `calculate.clone.polygons` assign angle calculation to be conducted using `calculate.angle.fixed`, which assumes radial mode. This PR fixes the conditions in `calculate.clone.polygons` so that dendrogram modes always uses `calculate.angle.radial`.

### Closes #149 

 ### Fixed tree:
<img width="132" alt="Screenshot 2024-11-18 at 12 28 24 PM" src="https://github.com/user-attachments/assets/49e982b9-0158-4183-bdd5-38d75998dfa6">

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

