### PR TITLE
Fix polygon siblings issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CancerEvolutionVisualization
 Title: Publication Quality Phylogenetic Tree Plots
 Version: 3.0.0
-Date: 2025-01-06
+Date: 2025-01-07
 Authors@R: c(
 	person("Paul Boutros", role = "cre", email = "PBoutros@mednet.ucla.edu"),
 	person("Adriana Salcedo", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# CancerEvolutionVisualization 3.0.0 (2025-01-06)
+# CancerEvolutionVisualization 3.0.0 (2025-01-07)
 
 ## Added
 * Dendrogram mode
@@ -27,6 +27,7 @@
 * Report the number of SNVs per clone in the legend for the clone-genome distribution plot.
 * Updated the user guide to reflect new features.
 * Fix bug where the x-axis only renders when y-axis is also rendered.
+* Fix issue when creating polygons with more than 2 siblings
 
 ## Bug
 * Resolved issue where the spread parameter was not applied in dendrogram mode.

--- a/R/calculate.clone.polygons.R
+++ b/R/calculate.clone.polygons.R
@@ -140,14 +140,14 @@ position.polygons <- function(
 				parent.angle <- atan(dist / par$len);
 			    }
 		} else {
-			if (v$id == siblings$id[which.min(siblings$x.mid)]) {
+			if (vi$id == siblings$id[which.min(siblings$x.mid)]) {
 			    # Align leftmost child with left outer clone border
 				parent.angle <- ifelse(
 				    is.null(fixed.angle),
 				    yes = atan(-(abs(par$x1) / par$len)),
 				    no = -(fixed.angle)
 				    );
-			} else if (v$id == siblings$id[which.max(siblings$x.mid)]) {
+			} else if (vi$id == siblings$id[which.max(siblings$x.mid)]) {
 			    # Align rightmost child with right outer clone border
 				parent.angle <- ifelse(
 				    is.null(fixed.angle),


### PR DESCRIPTION
# Description
Closes #159. There's an aesthetic issue with node spacing in the example with more than three siblings, but I don't think this is a bug per-se (and probably not the same bug that this change fixes). Let me know if this behaviour makes sense for now. If so, we can merge this fix before addressing polygon angles more generally.

## Examples

**Three Siblings**
```
phy.dt <- data.frame(
    parent = c(NA, 1, 1, 2, 1),
    label = c(1:5),
    CP = c(1.2, 0.5, 0.4, 0.2, 0.3)
    );
grid.draw(SRCGrob(phy.dt));
```
<img width="444" alt="Screenshot 2025-01-07 at 5 34 06 PM" src="https://github.com/user-attachments/assets/067d54fd-aa09-446d-8f8e-5604c613609a" />

**Four Siblings**
```
phy.dt <- data.frame(
    parent = c(NA, 1, 1, 1, 2, 1),
    label = c(1:6),
    CP = c(1.2, 0.5, 0.4, 0.2, 0.3, 0.15)
    );
grid.draw(SRCGrob(phy.dt));
```
<img width="400" alt="Screenshot 2025-01-07 at 5 39 05 PM" src="https://github.com/user-attachments/assets/109fc12f-b45e-4e1a-848f-3b12c52c66cb" />


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

